### PR TITLE
Complete Issue #3: Add centralized type exports

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Central export point for all type definitions
+ * 
+ * This file provides a single import location for all call graph types,
+ * making it easier to consume types throughout the application.
+ * 
+ * @example
+ * ```typescript
+ * import { CallGraph, CallGraphNode, CallGraphEdge } from '../types';
+ * ```
+ */
+
+// Core call graph data structures
+export * from './CallGraph';
+
+// Re-export commonly used types for convenience
+export type {
+  CallGraph,
+  CallGraphNode,
+  CallGraphEdge,
+  CallGraphMetadata,
+  CallGraphParameter,
+  CallGraphAnalysisOptions,
+  CallGraphMetrics,
+  CallGraphValidationResult,
+  CallGraphSpecification,
+  FormatterOptions,
+  OutputFormat,
+  AnalysisError,
+  EntryPointLocation,
+  ProjectContext,
+} from './CallGraph';
+
+// Re-export error classes
+export { CallGraphError } from './CallGraph';


### PR DESCRIPTION
## Summary
Completes Issue #3 by adding the missing centralized type exports file. The core type definitions were already comprehensively implemented and exceeded the original requirements.

## Changes
- ✅ **Add `src/types/index.ts`** - Central export point for all type definitions
- ✅ **Enable clean imports** - `import { CallGraph } from '../types'`
- ✅ **Comprehensive JSDoc** - Documentation for usage examples

## Issue #3 Status: ✅ COMPLETE
All requirements have been met and exceeded:

### ✅ What Was Already Implemented
- `CallGraphNode`, `CallGraphEdge`, `CallGraph` interfaces (enhanced versions)
- `CallGraphAnalysisOptions` (covers `AnalyzerOptions` requirement)  
- `FormatterOptions` (covers CLI options requirement)
- Advanced types: `CallGraphMetrics`, `ProjectContext`, `EntryPointLocation`
- Error handling: `CallGraphError`, `AnalysisError`
- Validation types: `CallGraphValidationResult`, `CallGraphSpecification`

### ✅ What This PR Adds
- **Missing centralized exports** via `src/types/index.ts`
- **Clean import syntax** for consuming types throughout the app
- **Proper module organization** following TypeScript best practices

## Impact
- **Type Foundation Complete** - Solid TypeScript foundation for entire application
- **Developer Experience** - Easy imports: `import { CallGraph } from '../types'`
- **No Breaking Changes** - Purely additive enhancement

## Test Plan
- [x] TypeScript compilation successful (`npm run type-check`)
- [x] No ESLint errors
- [x] All existing functionality preserved
- [x] Issue #3 verified complete and closed

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)